### PR TITLE
Add MPRA/STARR-seq common file format as table

### DIFF
--- a/as/mpra_starr.as
+++ b/as/mpra_starr.as
@@ -1,0 +1,15 @@
+table mpra_starr
+"BED6+5 MPRA/STARR-seq common file format"
+(
+string  chrom;		"Reference sequence chromosome or scaffold"
+uint    chromStart;	"Start position in chromosome"
+uint    chromEnd;	"End position in chromosome"
+string  name;		"Name of tested element or region"
+uint    score;		"Indicates how dark the peak will be displayed in the browser (0-1000)"
+char[1] strand;		"+ or - for strand, . for unknown"
+float   log2FoldChange;	"Fold change (normalized output/input ratio, in log2 space)"
+float   inputCount;	"Input count, mean across replicates"
+float   outputCount;	"Output count, mean across replicates"
+float   minusLog10PValue;	"-log10 of P-value"
+float   minusLog10QValue;	"-log10 of Q-value (FDR i.e., Benjamini-Hochberg False Discovery Rate)"
+)


### PR DESCRIPTION
Add table associated to the MPRA/STARR-seq common file format. 
```
$ validateFiles -as=/data/reddylab/Alex/software/encValData/as/mpra_starr.as  -chromInfo=/data/reddylab/Alex/software/encValData/GRCh38/GRCh38.chrom.sizes -type=bed6+5 /data/reddylab/Alex/tmp/atacSTARR.csaw.hg38.v05.common_file_formatted.bed
Error count 0
```


